### PR TITLE
Peering refactor

### DIFF
--- a/core/work_process/pull_tx_server/pull_tx_server.go
+++ b/core/work_process/pull_tx_server/pull_tx_server.go
@@ -57,7 +57,7 @@ func (d *PullTxServer) consume(inp *Input) {
 	metadata, err := txmetadata.TransactionMetadataFromBytes(metadataBytes)
 	util.AssertNoError(err)
 
-	d.SendTxBytesWithMetadataToPeer(inp.PeerID, txBytes, metadata)
+	go d.SendTxBytesWithMetadataToPeer(inp.PeerID, txBytes, metadata)
 	d.responseToPullCounter.Inc()
 
 	d.Tracef(TraceTag, "FOUND %s -> %s", inp.TxID.StringShort, peering.ShortPeerIDString(inp.PeerID))

--- a/peering/autopeering.go
+++ b/peering/autopeering.go
@@ -20,7 +20,7 @@ func (ps *Peers) isCandidateToConnect(id peer.ID) (yes bool) {
 		return
 	}
 	ps.withPeer(id, func(p *Peer) {
-		yes = p == nil && !ps._isInBlacklist(id) && !ps._isInCoolOffList(id)
+		yes = p == nil && !ps._isInBlacklist(id) && !ps._isInCoolOffList(id) && !ps._isInConnectList(id)
 	})
 	return
 }

--- a/peering/autopeering.go
+++ b/peering/autopeering.go
@@ -77,7 +77,7 @@ func (ps *Peers) dropExcessPeersIfNeeded() {
 	}
 	for _, p := range sortedDynamicPeers[:len(sortedDynamicPeers)-ps.cfg.MaxDynamicPeers] {
 		if time.Since(p.whenAdded) > gracePeriodAfterAdded {
-			ps._dropPeer(p, "excess peer (by rank)")
+			ps._dropPeer(p, "excess peer (by rank)", true)
 		}
 	}
 }

--- a/peering/autopeering.go
+++ b/peering/autopeering.go
@@ -20,7 +20,7 @@ func (ps *Peers) isCandidateToConnect(id peer.ID) (yes bool) {
 		return
 	}
 	ps.withPeer(id, func(p *Peer) {
-		yes = p == nil && !ps._isInBlacklist(id)
+		yes = p == nil && !ps._isInBlacklist(id) && !ps._isInCoolOffList(id)
 	})
 	return
 }

--- a/peering/heartbeat.go
+++ b/peering/heartbeat.go
@@ -98,6 +98,15 @@ func (ps *Peers) heartbeatStreamHandler(stream network.Stream) {
 		ps.Log().Infof("[peering] incoming peer request. Add new dynamic peer %s", id.String())
 	}
 
+	ps.Log().Info("[peering] hb: ******** streamHandler started for %s", ShortPeerIDString(id))
+
+	// receive start
+	_, err := readFrame(stream)
+	if err != nil {
+		ps.Log().Errorf("[peering] hb: error while reading start message from peer %s: err='%v'", ShortPeerIDString(id), err)
+		return
+	}
+
 	for {
 		var hbInfo heartbeatInfo
 		msgData, err := readFrame(stream)

--- a/peering/heartbeat.go
+++ b/peering/heartbeat.go
@@ -171,7 +171,9 @@ func (ps *Peers) sendHeartbeatToPeer(id peer.ID, hbCounter uint32) {
 	if blacklisted {
 		// ignore
 		ps.Tracef(TraceTagHeartBeatSend, "node #%d blacklisted. Ignore", ShortPeerIDString(id))
-		peer.numHBSendErr = 0
+		if peer != nil {
+			peer.numHBSendErr = 0
+		}
 		return
 	}
 

--- a/peering/heartbeat.go
+++ b/peering/heartbeat.go
@@ -183,9 +183,7 @@ func (ps *Peers) sendHeartbeatToPeer(id peer.ID, hbCounter uint32) {
 		counter:                hbCounter,
 		clock:                  time.Now(),
 	}
-	if err := ps.sendMsgBytesOut(id, ps.lppProtocolHeartbeat, msg.Bytes(), ps.cfg.SendTimeoutHeartbeat); err != nil {
-		ps.Tracef(TraceTagHeartBeatSend, ">>>>>>> failed to sent #%d to %s: %v", hbCounter, ShortPeerIDString(id), err)
-	} else {
+	if ps.sendMsgBytesOut(id, ps.lppProtocolHeartbeat, msg.Bytes()) {
 		ps.Tracef(TraceTagHeartBeatSend, ">>>>>>> sent #%d to %s", hbCounter, ShortPeerIDString(id))
 	} else {
 		peer.numHBSendErr++

--- a/peering/heartbeat.go
+++ b/peering/heartbeat.go
@@ -92,7 +92,10 @@ func (ps *Peers) heartbeatStreamHandler(stream network.Stream) {
 	}
 
 	go func() {
-		defer stream.Close()
+		defer func() {
+			stream.Close()
+			ps.Log().Errorf("[peering] hb: streamHandler exit")
+		}()
 		for {
 			var hbInfo heartbeatInfo
 			msgData, err := readFrame(stream)

--- a/peering/heartbeat.go
+++ b/peering/heartbeat.go
@@ -80,7 +80,6 @@ func (ps *Peers) heartbeatStreamHandler(stream network.Stream) {
 	remote := stream.Conn().RemoteMultiaddr()
 
 	known, blacklisted, _ := ps.knownPeer(id, func(p *Peer) {
-		p.numIncomingHB++
 	})
 	if blacklisted {
 		// ignore

--- a/peering/heartbeat.go
+++ b/peering/heartbeat.go
@@ -166,14 +166,16 @@ func (ps *Peers) sendHeartbeatToPeer(id peer.ID, hbCounter uint32) {
 		respondsToPull = ps.staticPeers.Contains(id)
 	}
 	peer := ps.getPeer(id)
+	if peer == nil {
+		ps.Tracef(TraceTagHeartBeatSend, "peer for node #%d nil. Ignore", ShortPeerIDString(id))
+		return
+	}
 	_, blacklisted, _ := ps.knownPeer(id, func(p *Peer) {
 	})
 	if blacklisted {
 		// ignore
-		ps.Tracef(TraceTagHeartBeatSend, "node #%d blacklisted. Ignore", ShortPeerIDString(id))
-		if peer != nil {
-			peer.numHBSendErr = 0
-		}
+		ps.Tracef(TraceTagHeartBeatSend, "node #%s blacklisted. Ignore", ShortPeerIDString(id))
+		peer.numHBSendErr = 0
 		return
 	}
 

--- a/peering/misc.go
+++ b/peering/misc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sync"
 
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -38,7 +39,12 @@ func readFrame(stream network.Stream) ([]byte, error) {
 	return msgBuf, nil
 }
 
+var writeMutex sync.Mutex
+
 func writeFrame(stream network.Stream, payload []byte) error {
+	writeMutex.Lock()
+	defer writeMutex.Unlock()
+
 	if len(payload) > MaxPayloadSize {
 		return fmt.Errorf("payload size %d exceeds maximum %d bytes", len(payload), MaxPayloadSize)
 	}

--- a/peering/misc.go
+++ b/peering/misc.go
@@ -52,7 +52,7 @@ func writeFrame(stream network.Stream, payload []byte) error {
 		if err == nil {
 			err = fmt.Errorf("expected %d bytes written", len(payload))
 		}
-		return fmt.Errorf("failed to write size prefix: %v", err)
+		return fmt.Errorf("failed to write paylod: %v", err)
 	}
 	return nil
 }

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -65,8 +65,9 @@ func TestBasic1(t *testing.T) {
 		t.Logf("%s : %s", name, ma.String())
 	}
 	env := newEnvironment()
-	_, err := New(env, cfg)
+	peers, err := New(env, cfg)
 	require.NoError(t, err)
+	peers.host.Close()
 }
 
 func TestBasic2(t *testing.T) {

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -106,6 +106,7 @@ func TestHeartbeat(t *testing.T) {
 	}
 	time.Sleep(10 * time.Second)
 	for _, ps := range hosts {
+		require.True(t, len(ps.getPeerIDs()) == numHosts-1)
 		for _, id := range ps.getPeerIDs() {
 			require.True(t, ps.IsAlive(id))
 		}

--- a/peering/peers.go
+++ b/peering/peers.go
@@ -592,11 +592,11 @@ func (ps *Peers) sendMsgBytesOut(peerID peer.ID, protocolID protocol.ID, data []
 		//time.Sleep(10 * time.Millisecond)
 	}
 	ps.outMsgCounter.Inc()
-	return err
+	return err == nil
 }
 
 // sendMsgBytesOutMulti send to multiple peers in parallel
-func (ps *Peers) sendMsgBytesOutMulti(peerIDs []peer.ID, protocolID protocol.ID, data []byte) {
+func (ps *Peers) sendMsgBytesOutMulti(peerIDs []peer.ID, protocolID protocol.ID, data []byte, timeout ...time.Duration) {
 	for _, id := range peerIDs {
 		idCopy := id
 		go ps.sendMsgBytesOut(idCopy, protocolID, data, timeout...)

--- a/peering/peers.go
+++ b/peering/peers.go
@@ -595,7 +595,7 @@ func (ps *Peers) sendMsgBytesOut(peerID peer.ID, protocolID protocol.ID, data []
 func (ps *Peers) sendMsgBytesOutMulti(peerIDs []peer.ID, protocolID protocol.ID, data []byte) {
 	for _, id := range peerIDs {
 		idCopy := id
-		ps.sendMsgBytesOut(idCopy, protocolID, data, timeout...)
+		go ps.sendMsgBytesOut(idCopy, protocolID, data, timeout...)
 	}
 }
 

--- a/peering/peers.go
+++ b/peering/peers.go
@@ -54,7 +54,7 @@ func New(env environment, cfg *Config) (*Peers, error) {
 		libp2p.NoSecurity,
 		libp2p.DisableRelay(),
 		libp2p.AddrsFactory(FilterAddresses(cfg.AllowLocalIPs)),
-		libp2p.QUICReuse(reuse.NewConnManager), //??
+		libp2p.QUICReuse(reuse.NewConnManager),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable create libp2p host: %w", err)
@@ -333,7 +333,6 @@ func (ps *Peers) _addPeer(addrInfo *peer.AddrInfo, name string, static bool) *Pe
 		defer ps.mutex.Unlock()
 		ps.peers[addrInfo.ID] = p
 	}()
-	//?? loop here infinitly if statis
 	return p
 }
 
@@ -347,10 +346,6 @@ func (ps *Peers) dropPeer(id peer.ID, reason string) {
 }
 
 func (ps *Peers) _dropPeer(p *Peer, reason string) {
-	//?? if p.isStatic {
-	// 	ps._addToBlacklist(p.id, reason)
-	// 	return
-	// }
 
 	why := ""
 	if len(reason) > 0 {
@@ -393,7 +388,7 @@ func (ps *Peers) restartBlacklistTime(id peer.ID) {
 
 func (ps *Peers) _addToCoolOfflist(id peer.ID) {
 	//ps.Log().Infof("[peering] node is connected to %d peer(s). Static: %d/%d, dynamic %d/%d, pull targets: %d (%v)",
-	ps.Log().Infof("[peering] ****** add to coooloff list peer %s", ShortPeerIDString(id))
+	ps.Log().Infof("[peering] ****** add to cooloff list peer %s", ShortPeerIDString(id))
 
 	ps.cooloffList[id] = time.Now().Add(cooloffTTL)
 }

--- a/peering/peers.go
+++ b/peering/peers.go
@@ -297,25 +297,18 @@ func (ps *Peers) dialPeer(peerID peer.ID, peer *Peer, static bool) error {
 	peer.streams[ps.lppProtocolHeartbeat] = &peerStream{
 		stream: stream,
 	}
-	//time.Sleep(1000 * time.Millisecond) //?? Delay
 	stream, err = ps.NewStream(peerID, ps.lppProtocolPull, timeout)
 	if err != nil {
-		// if static {
-		// 	time.Sleep(1 * time.Second)
-		// 	continue
-		// } else {
 		for _, s := range peer.streams {
 			if s.stream != nil {
 				s.stream.Close()
 			}
 		}
 		return err
-		//}
 	}
 	peer.streams[ps.lppProtocolPull] = &peerStream{
 		stream: stream,
 	}
-	//time.Sleep(1000 * time.Millisecond) //?? Delay
 	stream, err = ps.NewStream(peerID, ps.lppProtocolGossip, timeout)
 	if err != nil {
 		for _, s := range peer.streams {
@@ -346,7 +339,6 @@ func (ps *Peers) _addPeer(addrInfo *peer.AddrInfo, name string, static bool) *Pe
 	}
 
 	go func() {
-		//time.Sleep(1000 * time.Millisecond) //?? Delay
 		time.Sleep(100 * time.Millisecond) //?? Delay
 		err := ps.dialPeer(addrInfo.ID, p, static)
 		if err != nil {
@@ -354,7 +346,11 @@ func (ps *Peers) _addPeer(addrInfo *peer.AddrInfo, name string, static bool) *Pe
 			ps.host.Peerstore().RemovePeer(addrInfo.ID)
 			ps.mutex.Lock()
 			ps._removeFromConnectList(addrInfo.ID)
-			ps._addToBlacklist(addrInfo.ID, err.Error())
+			if static {
+				ps._addToBlacklist(addrInfo.ID, err.Error())
+			} else {
+				ps._addToCoolOfflist(addrInfo.ID)
+			}
 			ps.mutex.Unlock()
 			return
 		}

--- a/peering/peers.go
+++ b/peering/peers.go
@@ -234,7 +234,6 @@ func (ps *Peers) Stop() {
 		ps.Log().Infof("[peering] stopping libp2p host %s (self)..", ShortPeerIDString(ps.host.ID()))
 		_ = ps.Log().Sync()
 		_ = ps.kademliaDHT.Close()
-		_ = ps.host.Network().Close()
 		_ = ps.host.Close()
 		ps.Log().Infof("[peering] libp2p host %s (self) has been stopped", ShortPeerIDString(ps.host.ID()))
 	})

--- a/peering/peers.go
+++ b/peering/peers.go
@@ -396,6 +396,8 @@ func (ps *Peers) _dropPeer(p *Peer, reason string) {
 }
 
 func (ps *Peers) _addToBlacklist(id peer.ID, reason string) {
+	ps.Log().Infof("[peering] ****** add to blacklist peer %s", ShortPeerIDString(id))
+	ps._removeFromCoolOffList(id)
 	ps.blacklist[id] = _deadlineWithReason{
 		Time:   time.Now().Add(blacklistTTL),
 		reason: reason,
@@ -415,7 +417,18 @@ func (ps *Peers) restartBlacklistTime(id peer.ID) {
 func (ps *Peers) _addToCoolOfflist(id peer.ID) {
 	ps.Log().Infof("[peering] ****** add to cooloff list peer %s", ShortPeerIDString(id))
 
-	ps.cooloffList[id] = time.Now().Add(cooloffTTL)
+	if !ps._isInBlacklist(id) {
+		ps.cooloffList[id] = time.Now().Add(cooloffTTL)
+	}
+}
+
+func (ps *Peers) _removeFromCoolOffList(id peer.ID) {
+	ps.Log().Infof("[peering] ****** add to cooloff list peer %s", ShortPeerIDString(id))
+
+	_, found := ps.cooloffList[id]
+	if found {
+		delete(ps.cooloffList, id)
+	}
 }
 
 func (ps *Peers) _addToConnectList(id peer.ID) {

--- a/peering/peers.go
+++ b/peering/peers.go
@@ -23,7 +23,6 @@ import (
 	"github.com/lunfardo314/proxima/api"
 	"github.com/lunfardo314/proxima/core/txmetadata"
 	"github.com/lunfardo314/proxima/ledger"
-	"github.com/lunfardo314/proxima/util"
 	"github.com/lunfardo314/proxima/util/set"
 	"github.com/multiformats/go-multiaddr"
 	"golang.org/x/exp/maps"
@@ -645,7 +644,6 @@ func (ps *Peers) sendMsgBytesOut(peerID peer.ID, protocolID protocol.ID, data []
 		ps.Log().Errorf("[peering] error while sending message to peer %s len=%d id=%s stream==nil", ShortPeerIDString(peerID), len(data), protocolID)
 		return false
 	}
-	util.Assertf(stream != nil, "stream != nil")
 	if err = writeFrame(stream, data); err != nil {
 		ps.Log().Errorf("[peering] error while sending message to peer %s len=%d id=%s err=%v", ShortPeerIDString(peerID), len(data), protocolID, err)
 	}

--- a/peering/pull.go
+++ b/peering/pull.go
@@ -15,10 +15,9 @@ import (
 const PullTransactions = byte(iota)
 
 func (ps *Peers) pullStreamHandler(stream network.Stream) {
-	ps.inMsgCounter.Inc()
 	if ps.cfg.IgnoreAllPullRequests {
 		// ignore all pull requests
-		_ = stream.Close()
+		//_ = stream.Close()
 		return
 	}
 
@@ -29,38 +28,56 @@ func (ps *Peers) pullStreamHandler(stream network.Stream) {
 	})
 	if !known || blacklisted {
 		// just ignore
-		_ = stream.Close()
+		//_ = stream.Close()
 		return
 	}
 	if !static && ps.cfg.AcceptPullRequestsFromStaticPeersOnly {
 		// ignore pull requests from automatic peers
-		_ = stream.Close()
+		//_ = stream.Close()
 		return
 	}
 
-	msgData, err := readFrame(stream)
-	_ = stream.Close()
+	go func() {
+		defer stream.Close()
+		for {
+			msgData, err := readFrame(stream)
+			known, blacklisted, static := ps.knownPeer(id, func(p *Peer) {
+				p.numIncomingPull++
+			})
+			if !known || blacklisted {
+				// just ignore
+				//_ = stream.Close()
+				return
+			}
+			if !static && ps.cfg.AcceptPullRequestsFromStaticPeersOnly {
+				// ignore pull requests from automatic peers
+				//_ = stream.Close()
+				return
+			}
 
-	switch {
-	case err != nil:
-		ps.Log().Error("pull: error while reading message from peer %s: %v", id.String(), err)
-		return
-	case len(msgData) == 0:
-		ps.Log().Error("pull: error while reading message from peer %s: empty data", id.String())
-		return
-	case msgData[0] != PullTransactions:
-		ps.Log().Error("pull: wrong msg type '%d'", msgData[0])
-		return
-	}
+			ps.inMsgCounter.Inc()
+			switch {
+			case err != nil:
+				ps.Log().Error("pull: error while reading message from peer %s: %v", id.String(), err)
+				return
+			case len(msgData) == 0:
+				ps.Log().Error("pull: error while reading message from peer %s: empty data", id.String())
+				return
+			case msgData[0] != PullTransactions:
+				ps.Log().Error("pull: wrong msg type '%d'", msgData[0])
+				return
+			}
 
-	var txid ledger.TransactionID
-	txid, err = decodePullTransactionMsg(msgData)
-	if err != nil {
-		ps.Log().Error("pull: error while decoding message: %v", err)
-		return
-	}
-	ps.onReceivePullTx(id, txid)
-	ps.pullRequestsIn.Inc()
+			var txid ledger.TransactionID
+			txid, err = decodePullTransactionMsg(msgData)
+			if err != nil {
+				ps.Log().Error("pull: error while decoding message: %v", err)
+				return
+			}
+			ps.onReceivePullTx(id, txid)
+			ps.pullRequestsIn.Inc()
+		}
+	}()
 }
 
 func (ps *Peers) sendPullTransactionToPeers(ids []peer.ID, txid ledger.TransactionID) {

--- a/peering/pull.go
+++ b/peering/pull.go
@@ -38,7 +38,10 @@ func (ps *Peers) pullStreamHandler(stream network.Stream) {
 	}
 
 	go func() {
-		defer stream.Close()
+		defer func() {
+			stream.Close()
+			ps.Log().Errorf("[peering] pull: streamHandler exit")
+		}()
 		for {
 			msgData, err := readFrame(stream)
 			known, blacklisted, static := ps.knownPeer(id, func(p *Peer) {

--- a/peering/testutil.go
+++ b/peering/testutil.go
@@ -53,6 +53,7 @@ func MakeConfigFor(n, hostIdx int) *Config {
 		HostPort:              BeginPort + hostIdx,
 		PreConfiguredPeers:    make(map[string]_multiaddr),
 		ForcePullFromAllPeers: true,
+		MaxDynamicPeers:       10, // allow dynamic peers
 	}
 	ids := hostID[:n]
 	for i := range ids {

--- a/peering/testutil.go
+++ b/peering/testutil.go
@@ -10,6 +10,7 @@ import (
 )
 
 const BeginPort = 4000
+const TestBlacklistTTL = 20 // ms
 
 var (
 	allPrivateKeys = []string{
@@ -54,6 +55,9 @@ func MakeConfigFor(n, hostIdx int) *Config {
 		PreConfiguredPeers:    make(map[string]_multiaddr),
 		ForcePullFromAllPeers: true,
 		MaxDynamicPeers:       10, // allow dynamic peers
+		BlacklistTTL:          TestBlacklistTTL,
+		CooloffListTTL:        5,
+		DisableQuicreuse:      true, // with quic reuse enabled quic cannot be properly shutdown and subsequent tests will fail
 	}
 	ids := hostID[:n]
 	for i := range ids {

--- a/peering/txbytes.go
+++ b/peering/txbytes.go
@@ -60,6 +60,7 @@ func (ps *Peers) gossipStreamHandler(stream network.Stream) {
 			// protocol violation
 			err = fmt.Errorf("gossip: error while parsing tx message from peer %s: %v", id.String(), err)
 			ps.Log().Error(err)
+			ps.dropPeer(id, err.Error(), true)
 			return
 		}
 		metadata, err := txmetadata.TransactionMetadataFromBytes(metadataBytes)
@@ -67,6 +68,7 @@ func (ps *Peers) gossipStreamHandler(stream network.Stream) {
 			// protocol violation
 			err = fmt.Errorf("gossip: error while parsing tx message metadata from peer %s: %v", id.String(), err)
 			ps.Log().Error(err)
+			ps.dropPeer(id, err.Error(), true)
 			return
 		}
 

--- a/peering/txbytes.go
+++ b/peering/txbytes.go
@@ -79,7 +79,7 @@ func (ps *Peers) SendTxBytesWithMetadataToPeer(id peer.ID, txBytes []byte, metad
 		metadata: metadata,
 		txBytes:  txBytes,
 	}
-	return ps.sendMsgBytesOut(id, ps.lppProtocolGossip, msg.Bytes()) == nil
+	return ps.sendMsgBytesOut(id, ps.lppProtocolGossip, msg.Bytes())
 }
 
 // message wrapper

--- a/peering/types.go
+++ b/peering/types.go
@@ -151,7 +151,7 @@ const (
 	heartbeatRate      = 2 * time.Second
 	aliveNumHeartbeats = 10 // if no hb over this period, it means not-alive -> dynamic peer will be dropped
 	aliveDuration      = time.Duration(aliveNumHeartbeats) * heartbeatRate
-	blacklistTTL       = 10 * time.Second //?? 2 * time.Minute //20 * time.Second  //??
+	blacklistTTL       = 2 * time.Minute
 	cooloffTTL         = 10 * time.Second
 	// gracePeriodAfterAdded period of time peer is considered not dead after added even if messages are not coming
 	gracePeriodAfterAdded = 15 * heartbeatRate

--- a/peering/types.go
+++ b/peering/types.go
@@ -152,7 +152,7 @@ const (
 	heartbeatRate      = 2 * time.Second
 	aliveNumHeartbeats = 10 // if no hb over this period, it means not-alive -> dynamic peer will be dropped
 	aliveDuration      = time.Duration(aliveNumHeartbeats) * heartbeatRate
-	blacklistTTL       = 20 * time.Second //2 * time.Minute // //??
+	blacklistTTL       = 2 * time.Minute //20 * time.Second  //??
 	cooloffTTL         = 10 * time.Second
 	// gracePeriodAfterAdded period of time peer is considered not dead after added even if messages are not coming
 	gracePeriodAfterAdded = 15 * heartbeatRate

--- a/peering/types.go
+++ b/peering/types.go
@@ -63,6 +63,7 @@ type (
 		peers            map[peer.ID]*Peer // except self/host
 		staticPeers      set.Set[peer.ID]
 		blacklist        map[peer.ID]_deadlineWithReason
+		cooloffList      map[peer.ID]time.Time
 		// on receive handlers
 		onReceiveTx     func(from peer.ID, txBytes []byte, mdata *txmetadata.TransactionMetadata)
 		onReceivePullTx func(from peer.ID, txid ledger.TransactionID)
@@ -115,6 +116,8 @@ type (
 		numIncomingHB   int
 		numIncomingPull int
 		numIncomingTx   int
+
+		numHBSendErr int
 	}
 )
 
@@ -149,7 +152,8 @@ const (
 	heartbeatRate      = 2 * time.Second
 	aliveNumHeartbeats = 10 // if no hb over this period, it means not-alive -> dynamic peer will be dropped
 	aliveDuration      = time.Duration(aliveNumHeartbeats) * heartbeatRate
-	blacklistTTL       = 2 * time.Minute
+	blacklistTTL       = 20 * time.Second //2 * time.Minute // //??
+	cooloffTTL         = 10 * time.Second
 	// gracePeriodAfterAdded period of time peer is considered not dead after added even if messages are not coming
 	gracePeriodAfterAdded = 15 * heartbeatRate
 	logPeersEvery         = 5 * time.Second

--- a/peering/types.go
+++ b/peering/types.go
@@ -97,7 +97,7 @@ type (
 	Peer struct {
 		id                     peer.ID
 		name                   string
-		streams                [3]peerStream
+		streams                map[protocol.ID]*peerStream
 		isStatic               bool // statically pre-configured (manual peering)
 		respondsToPullRequests bool // from hb info
 		whenAdded              time.Time
@@ -135,9 +135,6 @@ const (
 	lppProtocolGossip    = "/proxima/gossip/%d"
 	lppProtocolPull      = "/proxima/pull/%d"
 	lppProtocolHeartbeat = "/proxima/heartbeat/%d"
-	lppGossipIdx         = 0
-	lppPullIdx           = 1
-	lppHeartBeatIdx      = 2
 
 	// clockTolerance is how big the difference between local and remote clocks is tolerated.
 	// The difference includes difference between local clocks (positive or negative) plus

--- a/peering/types.go
+++ b/peering/types.go
@@ -161,7 +161,7 @@ const (
 	heartbeatRate      = 2 * time.Second
 	aliveNumHeartbeats = 10 // if no hb over this period, it means not-alive -> dynamic peer will be dropped
 	aliveDuration      = time.Duration(aliveNumHeartbeats) * heartbeatRate
-	blacklistTTL       = 30 * time.Second //??2 * time.Minute
+	blacklistTTL       = 2 * time.Minute
 	cooloffTTL         = 10 * time.Second
 	// gracePeriodAfterAdded period of time peer is considered not dead after added even if messages are not coming
 	gracePeriodAfterAdded = 15 * heartbeatRate

--- a/peering/types.go
+++ b/peering/types.go
@@ -86,10 +86,15 @@ type (
 		peersPullTargets int
 	}
 
+	peerStream struct {
+		mutex  sync.RWMutex
+		stream network.Stream
+	}
+
 	Peer struct {
 		id                     peer.ID
 		name                   string
-		streams                [3]network.Stream
+		streams                [3]peerStream
 		isStatic               bool // statically pre-configured (manual peering)
 		respondsToPullRequests bool // from hb info
 		whenAdded              time.Time

--- a/peering/types.go
+++ b/peering/types.go
@@ -48,6 +48,9 @@ type (
 
 		BlacklistTTL   int
 		CooloffListTTL int
+
+		// disable Quicreuse
+		DisableQuicreuse bool
 	}
 
 	_multiaddr struct {
@@ -256,5 +259,6 @@ func readPeeringConfig() (*Config, error) {
 	if cfg.CooloffListTTL == 0 {
 		cfg.CooloffListTTL = int(cooloffTTL)
 	}
+	cfg.DisableQuicreuse = viper.GetBool("peering.disable_quicreuse")
 	return cfg, nil
 }

--- a/peering/types.go
+++ b/peering/types.go
@@ -64,6 +64,8 @@ type (
 		staticPeers      set.Set[peer.ID]
 		blacklist        map[peer.ID]_deadlineWithReason
 		cooloffList      map[peer.ID]time.Time
+		connectList      set.Set[peer.ID]
+
 		// on receive handlers
 		onReceiveTx     func(from peer.ID, txBytes []byte, mdata *txmetadata.TransactionMetadata)
 		onReceivePullTx func(from peer.ID, txid ledger.TransactionID)
@@ -152,7 +154,7 @@ const (
 	heartbeatRate      = 2 * time.Second
 	aliveNumHeartbeats = 10 // if no hb over this period, it means not-alive -> dynamic peer will be dropped
 	aliveDuration      = time.Duration(aliveNumHeartbeats) * heartbeatRate
-	blacklistTTL       = 2 * time.Minute //20 * time.Second  //??
+	blacklistTTL       = 10 * time.Second //?? 2 * time.Minute //20 * time.Second  //??
 	cooloffTTL         = 10 * time.Second
 	// gracePeriodAfterAdded period of time peer is considered not dead after added even if messages are not coming
 	gracePeriodAfterAdded = 15 * heartbeatRate

--- a/peering/types.go
+++ b/peering/types.go
@@ -46,7 +46,9 @@ type (
 		// timeout for heartbeat. If not set, used special defaultSendHeartbeatTimeout
 		SendTimeoutHeartbeat time.Duration
 
-		BlacklistTTL   int
+		// wait time to allow a blacklisted peer to connect again
+		BlacklistTTL int
+		// wait time after a disconnected peer can be reconnected again
 		CooloffListTTL int
 
 		// disable Quicreuse

--- a/peering/types.go
+++ b/peering/types.go
@@ -10,6 +10,7 @@ import (
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/discovery/routing"
@@ -88,6 +89,7 @@ type (
 	Peer struct {
 		id                     peer.ID
 		name                   string
+		streams                [3]network.Stream
 		isStatic               bool // statically pre-configured (manual peering)
 		respondsToPullRequests bool // from hb info
 		whenAdded              time.Time
@@ -123,6 +125,9 @@ const (
 	lppProtocolGossip    = "/proxima/gossip/%d"
 	lppProtocolPull      = "/proxima/pull/%d"
 	lppProtocolHeartbeat = "/proxima/heartbeat/%d"
+	lppGossipIdx         = 0
+	lppPullIdx           = 1
+	lppHeartBeatIdx      = 2
 
 	// clockTolerance is how big the difference between local and remote clocks is tolerated.
 	// The difference includes difference between local clocks (positive or negative) plus

--- a/tests/docker/1/proxi.yaml
+++ b/tests/docker/1/proxi.yaml
@@ -7,7 +7,7 @@ wallet:
 api:
     endpoint: http://0.0.0.0:8000
 tag_along:
-    sequencer_id: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+    sequencer_id: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     fee: 500
 finality:
     inclusion_threshold:
@@ -29,8 +29,8 @@ spammer:
     tag_along:
         fee: 500
         # <sequencer ID hex encoded> is tag-along sequencer ID for the tip transaction in the bundle
-        # For example the bootstrap sequencer af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
-        sequencer: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+        # For example the bootstrap sequencer 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
+        sequencer: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     # target address
     target: a(0x3faf090d38f18ea211936b8bcf19b7b30cdcb8e224394a5c30f9ba644f8bb2fb)
     trace_on_node: false

--- a/tests/docker/1/proxima.yaml
+++ b/tests/docker/1/proxima.yaml
@@ -84,7 +84,7 @@ sequencer:
     # start sequencer yes/no
     enable: false
     # chain ID of the sequencer
-    # chain ID af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963 is
+    # chain ID 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc is
     # predefined chain ID of the genesis chain (the bootstrap sequencer)
     # Sequencer chain is created by 'proxi node mkchain' command
     # All chains controlled by the wallet can be displayed by 'proxi node chains'

--- a/tests/docker/2/proxi.yaml
+++ b/tests/docker/2/proxi.yaml
@@ -8,7 +8,7 @@ wallet:
 api:
     endpoint: http://0.0.0.0:8000
 tag_along:
-    sequencer_id: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+    sequencer_id: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     fee: 500
 finality:
     inclusion_threshold:
@@ -30,8 +30,8 @@ spammer:
     tag_along:
         fee: 500
         # <sequencer ID hex encoded> is tag-along sequencer ID for the tip transaction in the bundle
-        # For example the bootstrap sequencer af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
-        sequencer: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+        # For example the bootstrap sequencer 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
+        sequencer: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     # target address
     target: a(0x3faf090d38f18ea211936b8bcf19b7b30cdcb8e224394a5c30f9ba644f8bb2fb)
     trace_on_node: false

--- a/tests/docker/2/proxima.yaml
+++ b/tests/docker/2/proxima.yaml
@@ -83,7 +83,7 @@ sequencer:
     # start sequencer yes/no
     enable: false
     # chain ID of the sequencer
-    # chain ID af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963 is
+    # chain ID 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc is
     # predefined chain ID of the genesis chain (the bootstrap sequencer)
     # Sequencer chain is created by 'proxi node mkchain' command
     # All chains controlled by the wallet can be displayed by 'proxi node chains'

--- a/tests/docker/3/proxi.yaml
+++ b/tests/docker/3/proxi.yaml
@@ -8,7 +8,7 @@ wallet:
 api:
     endpoint: http://0.0.0.0:8000
 tag_along:
-    sequencer_id: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+    sequencer_id: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     fee: 500
 finality:
     inclusion_threshold:
@@ -30,8 +30,8 @@ spammer:
     tag_along:
         fee: 500
         # <sequencer ID hex encoded> is tag-along sequencer ID for the tip transaction in the bundle
-        # For example the bootstrap sequencer af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
-        sequencer: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+        # For example the bootstrap sequencer 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
+        sequencer: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     # target address
     target: a(0x3faf090d38f18ea211936b8bcf19b7b30cdcb8e224394a5c30f9ba644f8bb2fb)
     trace_on_node: false

--- a/tests/docker/3/proxima.yaml
+++ b/tests/docker/3/proxima.yaml
@@ -84,7 +84,7 @@ sequencer:
     # start sequencer yes/no
     enable: false
     # chain ID of the sequencer
-    # chain ID af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963 is
+    # chain ID 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc is
     # predefined chain ID of the genesis chain (the bootstrap sequencer)
     # Sequencer chain is created by 'proxi node mkchain' command
     # All chains controlled by the wallet can be displayed by 'proxi node chains'

--- a/tests/docker/4/proxi.yaml
+++ b/tests/docker/4/proxi.yaml
@@ -8,7 +8,7 @@ wallet:
 api:
     endpoint: http://0.0.0.0:8000
 tag_along:
-    sequencer_id: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+    sequencer_id: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     fee: 500
 finality:
     inclusion_threshold:
@@ -30,8 +30,8 @@ spammer:
     tag_along:
         fee: 500
         # <sequencer ID hex encoded> is tag-along sequencer ID for the tip transaction in the bundle
-        # For example the bootstrap sequencer af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
-        sequencer: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+        # For example the bootstrap sequencer 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
+        sequencer: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     # target address
     target: a(0x3faf090d38f18ea211936b8bcf19b7b30cdcb8e224394a5c30f9ba644f8bb2fb)
     trace_on_node: false

--- a/tests/docker/4/proxima.yaml
+++ b/tests/docker/4/proxima.yaml
@@ -84,7 +84,7 @@ sequencer:
     # start sequencer yes/no
     enable: false
     # chain ID of the sequencer
-    # chain ID af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963 is
+    # chain ID 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc is
     # predefined chain ID of the genesis chain (the bootstrap sequencer)
     # Sequencer chain is created by 'proxi node mkchain' command
     # All chains controlled by the wallet can be displayed by 'proxi node chains'

--- a/tests/docker/boot/proxi.yaml
+++ b/tests/docker/boot/proxi.yaml
@@ -5,16 +5,16 @@ wallet:
     # <own sequencer ID> must be own sequencer ID, i.e. controlled by the private key of the wallet.
     # The controller wallet can withdraw tokens from the sequencer chain with command
     # 'proxi node seq withdraw'
-    sequencer_id: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+    sequencer_id: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
 api:
     # API endpoint  
     endpoint: http://0.0.0.0:8000
 
 tag_along:
     # ID of the tag-along sequencer. Currently only one
-    # In the bootstrap phase it normally is bootstrap chain ID: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+    # In the bootstrap phase it normally is bootstrap chain ID: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     # Later it is up to the wallet owner to set the preferred tag-along sequencer
-    sequencer_id: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+    sequencer_id: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     fee: 500
 finality:
     # finality rule used by the wallet. It has no effect on the way transaction is treated by the network
@@ -45,8 +45,8 @@ spammer:
     tag_along:
         fee: 500
         # <sequencer ID hex encoded> is tag-along sequencer ID for the tip transaction in the bundle
-        # For example the bootstrap sequencer af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
-        sequencer: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+        # For example the bootstrap sequencer 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
+        sequencer: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     # target address
     target: a(0x3faf090d38f18ea211936b8bcf19b7b30cdcb8e224394a5c30f9ba644f8bb2fb)
     trace_on_node: false

--- a/tests/docker/boot/proxima.yaml
+++ b/tests/docker/boot/proxima.yaml
@@ -82,11 +82,11 @@ sequencer:
     # start sequencer yes/no
     enable: true
     # chain ID of the sequencer
-    # chain ID af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963 is
+    # chain ID 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc is
     # predefined chain ID of the genesis chain (the bootstrap sequencer)
     # Sequencer chain is created by 'proxi node mkchain' command
     # All chains controlled by the wallet can be displayed by 'proxi node chains'
-    chain_id: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+    chain_id: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc
     # sequencer chain controller's private key (hex-encoded)
     controller_key: cd9e2cbfccff43c55f6127869762814431203203f359e86b57d804ff50a1b36dc07e104fcbec1daf388ffe50a6fd3ddf006d1e24a384ff81277fee6eff808738
     # sequencer pace. Distance in ticks between two subsequent sequencer transactions

--- a/tests/docker/boot/start.sh
+++ b/tests/docker/boot/start.sh
@@ -25,6 +25,10 @@ kill_proxima() {
     fi
 }
 
+# increase the maximum buffer for quic
+sysctl -w net.core.rmem_max=7500000
+sysctl -w net.core.wmem_max=7500000
+
 boot_param=""
 if [ "$NODE_NAME" = "boot" ]; then
 boot_param="boot"
@@ -67,6 +71,7 @@ if [ ! -f "$INITIALIZED_FILE" ]; then
 
         kill_proxima
         sleep 2  # let process die
+        #sleep 10  # wait for end of blacklisting
     fi 
 
     # Create the initialized file to mark the container as initialized

--- a/tests/docker/boot/start.sh
+++ b/tests/docker/boot/start.sh
@@ -71,7 +71,6 @@ if [ ! -f "$INITIALIZED_FILE" ]; then
 
         kill_proxima
         sleep 2  # let process die
-        #sleep 10  # wait for end of blacklisting
     fi 
 
     # Create the initialized file to mark the container as initialized

--- a/tests/node-docker-setup/node/proxima.genesis.id.yaml
+++ b/tests/node-docker-setup/node/proxima.genesis.id.yaml
@@ -21,4 +21,4 @@ max_number_of_endorsements: 8
 pre_branch_consolidation_ticks: 20
 description: Proxima prototype ledger. Ver 0.0.0
 genesis_controller_address: addressED25519(0xe29e38a1d44443fb66dfdc2481e8c98ba9a4cbf2f7b60eaf26b6d0722dae7a17)
-bootstrap_chain_id: af7bedde1fea222230b82d63d5b665ac75afbe4ad3f75999bb3386cf994a6963
+bootstrap_chain_id: 6393b6781206a652070e78d1391bc467e9d9704e9aa59ec7f7131f329d662dcc


### PR DESCRIPTION
This peering refactor removes the creating and deleting of a stream for every send/receive. 
The streams are only created when a new peer is connected. 
This should avoid the problem of peer losses.
